### PR TITLE
correct README.md compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ services:
   clone-hero-server:
     image: ghcr.io/athphane/clone-hero-server-docker:latest
     ports:
-      - "14242:14242"
+      - "14242:14242/udp"
     environment:
       SERVER_NAME: "My Clone Hero Server"
       SERVER_PASSWORD: rockon


### PR DESCRIPTION
README.md didn't use udp port forwarding for the compose example